### PR TITLE
Add oneline comment about future plan to explicitly explain it for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 SQLCommenter components for various languages
 
+**This repository is the temporary repository toward the migration to `contrib` repositories for each languages. See details in these tickets. [[1](https://github.com/open-telemetry/community/issues/783)][[2](https://github.com/open-telemetry/opentelemetry-java-contrib/issues/205)]**
+
  [Documentation](https://google.github.io/sqlcommenter/)
 
  Contains all the various `sqlcommenter-*` implementations.
 
- - [X] [Python](python/sqlcommenter-python/README.md)
-     - [X] [django](python/sqlcommenter-python/README.md#django)
-     - [X] [psycopg2](python/sqlcommenter-python/README.md#psycopg2)
-     - [X] [sqlalchemy](python/sqlcommenter-python/README.md#sqlalchemy)
- - [X] [Java](java/sqlcommenter-java/README.md)
-     - [X] [Hibernate](java/sqlcommenter-java/README.md#hibernate)
-     - [X] [Spring+Hibernate](java/sqlcommenter-java/README.md#spring-hibernate)
- - [X] Ruby
-     - [X] [Rails](ruby/sqlcommenter-ruby/sqlcommenter_rails/README.md)
- - [X] [Node.js](nodejs/sqlcommenter-nodejs/README.md)
-     - [X] [Knex.js](nodejs/sqlcommenter-nodejs/packages/sqlcommenter-knex/README.md)
-     - [X] [Sequelize.js](nodejs/sqlcommenter-nodejs/packages/sqlcommenter-sequelize/README.md)
+- [X] [Python](python/sqlcommenter-python/README.md)
+  - [X] [django](python/sqlcommenter-python/README.md#django)
+  - [X] [psycopg2](python/sqlcommenter-python/README.md#psycopg2)
+  - [X] [sqlalchemy](python/sqlcommenter-python/README.md#sqlalchemy)
+- [X] [Java](java/sqlcommenter-java/README.md)
+  - [X] [Hibernate](java/sqlcommenter-java/README.md#hibernate)
+  - [X] [Spring+Hibernate](java/sqlcommenter-java/README.md#spring-hibernate)
+- [X] Ruby
+  - [X] [Rails](ruby/sqlcommenter-ruby/sqlcommenter_rails/README.md)
+- [X] [Node.js](nodejs/sqlcommenter-nodejs/README.md)
+  - [X] [Knex.js](nodejs/sqlcommenter-nodejs/packages/sqlcommenter-knex/README.md)
+  - [X] [Sequelize.js](nodejs/sqlcommenter-nodejs/packages/sqlcommenter-sequelize/README.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 SQLCommenter components for various languages
 
-**This repository is the temporary repository toward the migration to `contrib` repositories for each languages. See details in these tickets. [[1](https://github.com/open-telemetry/community/issues/783)][[2](https://github.com/open-telemetry/opentelemetry-java-contrib/issues/205)]**
+**This repository is the temporary repository toward the migration to `contrib/instrumentation` repositories for each languages. See details in these tickets. [[1](https://github.com/open-telemetry/community/issues/783)][[2](https://github.com/open-telemetry/opentelemetry-java-contrib/issues/205)]**
 
  [Documentation](https://google.github.io/sqlcommenter/)
 


### PR DESCRIPTION
As of Apr 2022, it's not explicit if this repository is temporary for migration process, so I added the comment in the README so that users who don't know the context can refer to the background easily.